### PR TITLE
Add sprite animations and dynamic background

### DIFF
--- a/draw_contra_background.js
+++ b/draw_contra_background.js
@@ -1,18 +1,51 @@
 
+let backgroundTime = 0;
+
+function blendColors(c1, c2, t) {
+  const r1 = parseInt(c1.slice(1, 3), 16);
+  const g1 = parseInt(c1.slice(3, 5), 16);
+  const b1 = parseInt(c1.slice(5, 7), 16);
+  const r2 = parseInt(c2.slice(1, 3), 16);
+  const g2 = parseInt(c2.slice(3, 5), 16);
+  const b2 = parseInt(c2.slice(5, 7), 16);
+  const r = Math.round(r1 + (r2 - r1) * t);
+  const g = Math.round(g1 + (g2 - g1) * t);
+  const b = Math.round(b1 + (b2 - b1) * t);
+  return `rgb(${r},${g},${b})`;
+}
+
 function drawContraBackground(scrollX) {
-  // Sky gradient
+  backgroundTime += 0.002;
+  const cycle = (Math.sin(backgroundTime) + 1) / 2;
+
+  // Sky gradient with day/night cycle
+  const dayTop = "#87CEEB";
+  const dayBottom = "#F0F8FF";
+  const nightTop = "#000814";
+  const nightBottom = "#14213D";
   const skyGradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
-  skyGradient.addColorStop(0, "#000814");
-  skyGradient.addColorStop(1, "#14213D");
+  skyGradient.addColorStop(0, blendColors(dayTop, nightTop, cycle));
+  skyGradient.addColorStop(1, blendColors(dayBottom, nightBottom, cycle));
   ctx.fillStyle = skyGradient;
   ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-  // Moon (scrolls slowly)
-  const moonX = 150 - scrollX * 0.1;
+  // Sun/Moon
+  const celestialX = 150 - scrollX * 0.1;
   ctx.beginPath();
-  ctx.arc(moonX, 80, 40, 0, Math.PI * 2);
-  ctx.fillStyle = "#EAEAEA";
+  ctx.arc(celestialX, 80, 40, 0, Math.PI * 2);
+  ctx.fillStyle = cycle > 0.5 ? "#EAEAEA" : "#FFF799";
   ctx.fill();
+
+  // Clouds
+  ctx.fillStyle = "rgba(255,255,255,0.8)";
+  for (let i = 0; i < canvas.width + 200; i += 200) {
+    const cloudX = i - (scrollX * 0.1 % 200) + backgroundTime * 20;
+    ctx.beginPath();
+    ctx.ellipse(cloudX, 120, 40, 20, 0, 0, Math.PI * 2);
+    ctx.ellipse(cloudX + 30, 120, 50, 25, 0, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
 
   // Mountains (far layer)
   ctx.fillStyle = "#202020";


### PR DESCRIPTION
## Summary
- implement day-night cycle with clouds and parallax layers
- add animated sprite sheets for player and enemy

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842d27d34908322a677e954f229b2b8